### PR TITLE
Upgrade .NET SDK, Avalonia, fix issues #38 and #31

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build-publish-deploy-win:
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore ./ShareClipbrd/ShareClipbrd.sln
     - name: Build
@@ -28,7 +28,7 @@ jobs:
 
     - name: Publish
       run: |
-        dotnet publish "./ShareClipbrd\ShareClipbrdApp/ShareClipbrdApp.csproj" -c PublishRelease -r win-x64 -f net8.0-windows -p:PublishSingleFile=true --self-contained true -o "./out/win64" -p:DebugType=None
+        dotnet publish "./ShareClipbrd\ShareClipbrdApp/ShareClipbrdApp.csproj" -c PublishRelease -r win-x64 -f net10.0-windows -p:PublishSingleFile=true --self-contained true -o "./out/win64" -p:DebugType=None
 
     - name: Deploy Win64
       uses: actions/upload-artifact@v4
@@ -38,14 +38,14 @@ jobs:
         retention-days: 90
 
   build-publish-deploy-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore ./ShareClipbrd/ShareClipbrd.sln
     - name: Build
@@ -55,7 +55,7 @@ jobs:
 
     - name: Publish
       run: |
-        dotnet publish "./ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj" -c PublishRelease -r linux-x64 -f net8.0 -p:PublishSingleFile=true --self-contained true -o "./out/_linux64" -p:DebugType=None
+        dotnet publish "./ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj" -c PublishRelease -r linux-x64 -f net10.0 -p:PublishSingleFile=true --self-contained true -o "./out/_linux64" -p:DebugType=None
 
     - name: Tar Linux64 files 
       run: mkdir -p ./out/linux64 && tar -cjvf ./out/linux64/ShareClipbrd.tar -C ./out/_linux64/ . && rm -rf ./out/_linux64

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,16 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Core Launch",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/ShareClipbrd/ShareClipbrdApp/bin/Debug/net8.0-windows/ShareClipbrdApp.dll",
+            "program": "${workspaceFolder}/ShareClipbrd/ShareClipbrdApp/bin/Debug/net10.0/ShareClipbrdApp.dll",
             "args": [],
             "cwd": "${workspaceFolder}/ShareClipbrd/ShareClipbrdApp",
             "console": "internalConsole",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "justMyCode": false,
         },
         {
             "name": ".NET Core Attach",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "dotnet.defaultSolution": "ShareClipbrd/ShareClipbrd.sln"
+    "dotnet.defaultSolution": "ShareClipbrd/ShareClipbrd.sln",
+    "tabMagnet.rules": [
+        {
+            "left": "$(name).axaml.cs",
+            "right": "$(name).axaml"
+        }
+    ]
 }

--- a/ShareClipbrd/Clipboard.Core.Tests/Clipboard.Core.Tests.csproj
+++ b/ShareClipbrd/Clipboard.Core.Tests/Clipboard.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ShareClipbrd/Clipboard.Core.Tests/Clipboard.Core.Tests.csproj
+++ b/ShareClipbrd/Clipboard.Core.Tests/Clipboard.Core.Tests.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ShareClipbrd/Clipboard.Core.Tests/Helpers/WindowsHtmlFormatHelperTests.cs
+++ b/ShareClipbrd/Clipboard.Core.Tests/Helpers/WindowsHtmlFormatHelperTests.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using Clipboard.Core.Helpers;
+
+namespace Clipboard.Core.Tests.Helpers {
+    public class WindowsHtmlFormatHelperTests {
+
+        [Test]
+        public void ExtractHtmlFragment_ValidFormat_ReturnsFragment() {
+            var fullHtml = "Version:0.9\r\nStartHTML:0000000105\r\nEndHTML:0000000182\r\nStartFragment:0000000139\r\nEndFragment:0000000148\r\n<html><body>\r\n<!--StartFragment-->test text<!--EndFragment-->\r\n</body></html>";
+            var bytes = Encoding.UTF8.GetBytes(fullHtml);
+
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment(bytes);
+
+            var resultText = Encoding.UTF8.GetString(result);
+            Assert.That(resultText, Is.EqualTo("test text"));
+        }
+
+        [Test]
+        public void ExtractHtmlFragment_CyrillicContent_ReturnsFragment() {
+            var fullHtml = "Version:0.9\r\nStartHTML:0000000136\r\nEndHTML:0000000266\r\nStartFragment:0000000170\r\nEndFragment:0000000232\r\nSourceURL:https://example.com\r\n<html><body>\r\n<!--StartFragment-->Процесс, исход которого полностью<!--EndFragment-->\r\n</body></html>";
+            var bytes = Encoding.UTF8.GetBytes(fullHtml);
+
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment(bytes);
+
+            var resultText = Encoding.UTF8.GetString(result);
+            Assert.That(resultText, Is.EqualTo("Процесс, исход которого полностью"));
+        }
+
+        [Test]
+        public void ExtractHtmlFragment_NullInput_ReturnsEmptyArray() {
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment(null!);
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ExtractHtmlFragment_EmptyInput_ReturnsEmptyArray() {
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment([]);
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ExtractHtmlFragment_NoFragmentMarkers_ReturnsOriginal() {
+            var html = "<html><body>test</body></html>";
+            var bytes = Encoding.UTF8.GetBytes(html);
+
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment(bytes);
+
+            Assert.That(result, Is.EqualTo(bytes));
+        }
+
+        [Test]
+        public void ExtractHtmlFragment_InvalidOffsets_ReturnsOriginal() {
+            var windowsHtml = """
+                Version:0.9
+                StartFragment:9999999999
+                EndFragment:0000000010
+                <html><body>test</body></html>
+                """;
+            var bytes = Encoding.UTF8.GetBytes(windowsHtml);
+
+            var result = WindowsHtmlFormatHelper.ExtractHtmlFragment(bytes);
+
+            Assert.That(result, Is.EqualTo(bytes));
+        }
+    }
+}

--- a/ShareClipbrd/Clipboard.Core/Clipboard.Core.csproj
+++ b/ShareClipbrd/Clipboard.Core/Clipboard.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ShareClipbrd/Clipboard.Core/ClipboardData.cs
+++ b/ShareClipbrd/Clipboard.Core/ClipboardData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using Clipboard.Core.Helpers;
 
 namespace Clipboard.Core {
     public class ClipboardData {
@@ -288,7 +289,7 @@ namespace Clipboard.Core {
 
                     if(OperatingSystem.IsLinux()) {
                         return stream switch {
-                            MemoryStream memoryStream => memoryStream.ToArray(),
+                            MemoryStream memoryStream => WindowsHtmlFormatHelper.ExtractHtmlFragment(memoryStream.ToArray()),
                             _ => throw new ArgumentException(nameof(stream))
                         };
                     }

--- a/ShareClipbrd/Clipboard.Core/Helpers/WindowsHtmlFormatHelper.cs
+++ b/ShareClipbrd/Clipboard.Core/Helpers/WindowsHtmlFormatHelper.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Clipboard.Core.Helpers {
+    /// <summary>
+    /// Helper for parsing Windows HTML Clipboard Format.
+    /// Format specification: https://docs.microsoft.com/en-us/windows/win32/dataxchg/html-clipboard-format
+    /// </summary>
+    public static class WindowsHtmlFormatHelper {
+        static readonly Regex startFragmentRegex = new(@"StartFragment:(\d+)", RegexOptions.Compiled);
+        static readonly Regex endFragmentRegex = new(@"EndFragment:(\d+)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Extracts the HTML fragment from Windows HTML Clipboard Format.
+        /// </summary>
+        /// <param name="windowsHtmlFormat">Raw Windows HTML Format data</param>
+        /// <returns>Clean HTML fragment, or original data if parsing fails</returns>
+        public static byte[] ExtractHtmlFragment(byte[] windowsHtmlFormat) {
+            if(windowsHtmlFormat is null) {
+                return [];
+            }
+            if(!windowsHtmlFormat.Any()) {
+                return windowsHtmlFormat;
+            }
+
+            try {
+                var text = Encoding.UTF8.GetString(windowsHtmlFormat);
+
+                var startMatch = startFragmentRegex.Match(text);
+                var endMatch = endFragmentRegex.Match(text);
+
+                if(!startMatch.Success || !endMatch.Success) {
+                    return windowsHtmlFormat;
+                }
+
+                var startFragment = int.Parse(startMatch.Groups[1].Value);
+                var endFragment = int.Parse(endMatch.Groups[1].Value);
+
+                if(startFragment < 0 || endFragment <= startFragment || endFragment > windowsHtmlFormat.Length) {
+                    return windowsHtmlFormat;
+                }
+
+                var fragmentLength = endFragment - startFragment;
+                var fragment = new byte[fragmentLength];
+                Array.Copy(windowsHtmlFormat, startFragment, fragment, 0, fragmentLength);
+
+                return fragment;
+            } catch {
+                return windowsHtmlFormat;
+            }
+        }
+    }
+}

--- a/ShareClipbrd/Clipboard.Tests/Clipboard.Tests.csproj
+++ b/ShareClipbrd/Clipboard.Tests/Clipboard.Tests.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ShareClipbrd/Clipboard.Tests/Clipboard.Tests.csproj
+++ b/ShareClipbrd/Clipboard.Tests/Clipboard.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ShareClipbrd/Clipboard.Win/Clipboard.Win.csproj
+++ b/ShareClipbrd/Clipboard.Win/Clipboard.Win.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/ShareClipbrd/Clipboard.X11/Clipboard.X11.csproj
+++ b/ShareClipbrd/Clipboard.X11/Clipboard.X11.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ShareClipbrd/Clipboard/Clipboard.csproj
+++ b/ShareClipbrd/Clipboard/Clipboard.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ShareClipbrd/ShareClipbrd.Core.Tests/Services/ClientServerTests.cs
+++ b/ShareClipbrd/ShareClipbrd.Core.Tests/Services/ClientServerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Clipboard.Core;
 using Moq;
 using ShareClipbrd.Core.Configuration;
@@ -438,5 +439,35 @@ namespace ShareClipbrd.Core.Tests.Services {
             await server.Stop();
             client.Stop();
         }
+
+        [Test]
+        [Platform("Linux")]
+        [SupportedOSPlatform("linux")]
+        public async Task SendFileDropList_UnauthorizedAccessException_ShowsError() {
+            var testsPath = Path.Combine(Path.GetTempPath(), "tests_unauthorized");
+            Directory.CreateDirectory(testsPath);
+            var filename = Path.Combine(testsPath, "no_access.bin");
+            File.WriteAllBytes(filename, [1, 2, 3]);
+            File.SetUnixFileMode(filename, UnixFileMode.None);
+
+            var files = new StringCollection { filename };
+
+            var port = await server.Start();
+            systemConfigurationMock.SetupGet(x => x.PartnerAddress).Returns($"127.0.0.1:{port}");
+
+            try {
+                await client.SendFileDropList(files);
+
+                dialogServiceMock.Verify(
+                    x => x.ShowError(It.Is<UnauthorizedAccessException>(ex => ex != null)),
+                    Times.Once);
+            } finally {
+                File.SetUnixFileMode(filename, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                Directory.Delete(testsPath, true);
+                await server.Stop();
+                client.Stop();
+            }
+        }
+
     }
 }

--- a/ShareClipbrd/ShareClipbrd.Core.Tests/Services/ClientServerTests.cs
+++ b/ShareClipbrd/ShareClipbrd.Core.Tests/Services/ClientServerTests.cs
@@ -221,7 +221,7 @@ namespace ShareClipbrd.Core.Tests.Services {
                 Assert.That(fs.Length, Is.EqualTo(4096L * 1024 * 1024 + 1));
 
                 var otherBytes = new byte[1_000_003];
-                fs.Read(otherBytes);
+                fs.ReadExactly(otherBytes);
                 Assert.That(otherBytes, Is.EquivalentTo(bytes));
             }
             File.Delete(otherFilename);

--- a/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
@@ -23,8 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
@@ -15,14 +15,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core.Tests/ShareClipbrd.Core.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ShareClipbrd/ShareClipbrd.Core/Clipboard/FileTransmitter.cs
+++ b/ShareClipbrd/ShareClipbrd.Core/Clipboard/FileTransmitter.cs
@@ -50,7 +50,6 @@ namespace ShareClipbrd.Core.Clipboard {
             if(attributes.HasFlag(FileAttributes.Directory)) {
                 await networkStream.WriteAsync((Int64)0, cancellationToken);
             } else {
-
                 using(var fileStream = new FileStream(name, FileMode.Open, FileAccess.Read)) {
                     progressService.SetMaxMinorTick(fileStream.Length);
                     await networkStream.WriteAsync((Int64)fileStream.Length, cancellationToken);

--- a/ShareClipbrd/ShareClipbrd.Core/Services/DataClient.cs
+++ b/ShareClipbrd/ShareClipbrd.Core/Services/DataClient.cs
@@ -91,6 +91,8 @@ namespace ShareClipbrd.Core.Services {
                 await dialogService.ShowError(ex);
             } catch(IOException ex) {
                 await dialogService.ShowError(ex);
+            } catch(UnauthorizedAccessException ex) {
+                await dialogService.ShowError(ex);
             } catch(ArgumentException ex) {
                 await dialogService.ShowError(ex);
             } catch(OperationCanceledException) {

--- a/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
@@ -14,7 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
-    <PackageReference Include="System.IO.Hashing" Version="9.0.2" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 

--- a/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
@@ -15,8 +15,6 @@
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 

--- a/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
+++ b/ShareClipbrd/ShareClipbrd.Core/ShareClipbrd.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
@@ -23,8 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.1.5" />
-    <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
+    <PackageReference Include="Avalonia" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.11" />
+    <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
+++ b/ShareClipbrd/ShareClipbrdApp.Tests/ShareClipbrdApp.Tests.csproj
@@ -16,13 +16,15 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.11" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShareClipbrd/ShareClipbrdApp/Helpers/WindowsHelper.cs
+++ b/ShareClipbrd/ShareClipbrdApp/Helpers/WindowsHelper.cs
@@ -8,20 +8,10 @@ namespace ShareClipbrdApp.Helpers {
             if(point.IsEmpty) {
                 return;
             }
-            if(point.X + window.Width < 0) {
-                return;
-            }
-            if(point.Y + window.Height < 0) {
-                return;
-            }
+            var pixelPoint = new PixelPoint(point.X, point.Y);
 
-            var screensMaxWidth = window.Screens.All.Select(x => x.Bounds.X + x.Bounds.Width).Max();
-            if(point.X + window.Width / 2 > screensMaxWidth) {
-                return;
-            }
-
-            var screensMaxHeight = window.Screens.All.Select(y => y.Bounds.Y + y.Bounds.Height).Max();
-            if(point.Y + window.Height / 2 > screensMaxHeight) {
+            var fitToAnyScreen = window.Screens.All.Any(x => x.Bounds.Contains(pixelPoint));
+            if(!fitToAnyScreen) {
                 return;
             }
             window.Position = new PixelPoint(point.X, point.Y);

--- a/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml
+++ b/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml
@@ -45,14 +45,14 @@
         </ComboBox>
 
         <MenuItem Header="Host address">
-          <MenuItem>
+          <MenuItem StaysOpenOnClick="True" PropertyChanged="muHostAddress_PropertyChanged">
             <MenuItem.Header>
               <TextBox x:Name="edHostAddress" Width="250" Margin="0,0,-10,0" PropertyChanged="edHostAddress_PropertyChanged" />
             </MenuItem.Header>
           </MenuItem>
         </MenuItem>
         <MenuItem Header="Partner address" >
-          <MenuItem>
+          <MenuItem StaysOpenOnClick="True" PropertyChanged="muPartnerAddress_PropertyChanged">
             <MenuItem.Header>
               <TextBox x:Name="edPartnerAddress" Width="250" Margin="0,0,-10,0" PropertyChanged="edPartnerAddress_PropertyChanged"/>
             </MenuItem.Header>

--- a/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml.cs
+++ b/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml.cs
@@ -154,6 +154,13 @@ namespace ShareClipbrdApp {
             }
         }
 
+        private void muHostAddress_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) {
+            if(e.Property == TextBox.IsFocusedProperty) {
+                edHostAddress.Focus();
+                return;
+            }
+        }
+
         private void edPartnerAddress_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) {
             if(e.Property == TextBox.TextProperty) {
                 switch(systemConfiguration!.SettingsProfile) {
@@ -167,6 +174,13 @@ namespace ShareClipbrdApp {
                         Settings.Default.PartnerAddress2 = edPartnerAddress.Text;
                         break;
                 }
+            }
+        }
+
+        private void muPartnerAddress_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) {
+            if(e.Property == TextBox.IsFocusedProperty) {
+                edPartnerAddress.Focus();
+                return;
             }
         }
 

--- a/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml.cs
+++ b/ShareClipbrd/ShareClipbrdApp/MainWindow.axaml.cs
@@ -107,6 +107,13 @@ namespace ShareClipbrdApp {
             Opacity = 0.6;
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) {
+            base.OnPropertyChanged(change);
+            if(change.Property == WindowStateProperty && change.NewValue is WindowState newState) {
+                ShowInTaskbar = newState == WindowState.Minimized;
+            }
+        }
+
         void OnPointerPressedEvent(object? sender, PointerPressedEventArgs e) {
             if(e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) {
                 originalPoint = e.GetCurrentPoint(this);

--- a/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
+++ b/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net8.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux'))">net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
+++ b/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
@@ -30,13 +30,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.5" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.1.5" />
+    <PackageReference Include="Avalonia" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.11" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.5" />
-    <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.11" />
+    <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.2" />
   </ItemGroup>

--- a/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
+++ b/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
@@ -39,8 +39,6 @@
     <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
+++ b/ShareClipbrd/ShareClipbrdApp/ShareClipbrdApp.csproj
@@ -37,8 +37,10 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.11" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Обновление зависимостей

- **Upgrade .NET SDK** с 8.0 на 10.0
- **Bump Avalonia** до версии 11.3.11
- Обновлены остальные NuGet пакеты

### Issue #38 - Падение при копировании файлов без прав на чтение

При попытке скопировать файлы, принадлежащие root или без прав на чтение, приложение падало с `UnauthorizedAccessException`. 

**Исправление:** Добавлена обработка `UnauthorizedAccessException` в `DataClient.SendFileDropList()`.

### Issue #31 - Некорректная вставка HTML из Windows в Linux

При копировании текста из Chrome (Windows) и вставке в Firefox (Linux) вместо текста отображались служебные заголовки Windows HTML Format:

### Исправление минимизации окна на Linux

При использовании "Hide all windows" на панели задач Linux Mint, окно скрывалось и не могло быть восстановлено, так как у него отсутствовала кнопка на панели задач (`ShowInTaskbar="False"`).

**Исправление:** При минимизации окна автоматически включается `ShowInTaskbar = true`, что позволяет пользователю восстановить окно через панель задач. При восстановлении окна значок снова скрывается с панели.

